### PR TITLE
Make tests pass when window decorations are accessible

### DIFF
--- a/test/end_to_end/basic_run_test.rb
+++ b/test/end_to_end/basic_run_test.rb
@@ -11,7 +11,7 @@ describe "test driving a dummy application" do
 
   it "starts and can be quit by activating an action" do
     frame = @driver.frame
-    button = frame.find_role :push_button
+    button = frame.find_role :push_button, /Close/
     button.do_action 0
 
     status = @driver.cleanup
@@ -22,7 +22,7 @@ describe "test driving a dummy application" do
     app = @driver.application
     _(app.role).must_equal Atspi::Role::APPLICATION
 
-    button = app.find_role :push_button
+    button = app.find_role :push_button, /Close/
     button.do_action 0
 
     status = @driver.cleanup


### PR DESCRIPTION
When client side decorations are used, the frame buttons also become accessible. This means searching just any button may return, for example, the Minimize button. This will not close the application, causing the test to fail.

To avoid this problem, search for a button labeled 'Close' instead of just any button.
