### PR TITLE
Loosen RuboCop dependencies

### DIFF
--- a/gnome_app_driver.gemspec
+++ b/gnome_app_driver.gemspec
@@ -38,8 +38,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.12"
   spec.add_development_dependency "pry", "~> 0.14.0"
   spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rubocop", "~> 1.25.0"
+  spec.add_development_dependency "rubocop", "~> 1.25"
   spec.add_development_dependency "rubocop-minitest", "~> 0.17.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.13.0"
+  spec.add_development_dependency "rubocop-performance", "~> 1.13"
 end


### PR DESCRIPTION
This will decrease churn on the gemspec file. Updating the code for new offenses can be scheduled when it becomes necessary to make the build pass for new pull requests.
