### PR TITLE
Pass original role argument when recursing #find_role

### DIFF
--- a/lib/gnome_app_driver.rb
+++ b/lib/gnome_app_driver.rb
@@ -19,12 +19,13 @@ module AtspiAccessiblePatches
     end
   end
 
-  def find_role(role, regex = //)
-    role = Atspi::Role.new role
+  # Find an element with the given role and label regex
+  def find_role(role_name, regex = //)
+    role = Atspi::Role.new role_name
     return self if role == self.role && name =~ regex
 
     each_child do |child|
-      result = child.find_role role, regex
+      result = child.find_role role_name, regex
       return result if result
     end
     nil

--- a/test/end_to_end/basic_run_test.rb
+++ b/test/end_to_end/basic_run_test.rb
@@ -18,7 +18,7 @@ describe "test driving a dummy application" do
     _(status.exitstatus).must_equal 0
   end
 
-  it "provides acces to the main application Atspi object" do
+  it "provides access to the main application Atspi object" do
     app = @driver.application
     _(app.role).must_equal Atspi::Role::APPLICATION
 


### PR DESCRIPTION
The `Atspi::Role.new` method has the odd behavior that passing an object to the same class to it results in a no-op. So, the original method worked but was surprising. Instead, separate the role from its name to make the code clearer.
