### PR TITLE
Bump RuboCop to 1.34 to avoid configuration errors

### DIFF
--- a/gnome_app_driver.gemspec
+++ b/gnome_app_driver.gemspec
@@ -38,8 +38,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.12"
   spec.add_development_dependency "pry", "~> 0.14.0"
   spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rubocop", "~> 1.25"
+  spec.add_development_dependency "rubocop", "~> 1.34"
   spec.add_development_dependency "rubocop-minitest", "~> 0.21.0"
-  spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
+  spec.add_development_dependency "rubocop-packaging", "~> 0.5.1"
   spec.add_development_dependency "rubocop-performance", "~> 1.13"
 end


### PR DESCRIPTION
Version 1.33 of RuboCop broke `RuboCop::ConfigLoader.project_root`, leading to errors in rubocop-packaging. Require at least 1.34 to avoid this. The rubocop-packaging dependency is also updated because 0.5.0 could never be installed as it requires rubocop 0.89.
