### PR TITLE
Support Ruby 3.0 and up

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/gnome_app_driver.gemspec
+++ b/gnome_app_driver.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   DESC
   spec.homepage = "http://www.github.com/mvz/ruby-gnome2_app_driver"
   spec.license = "LGPL-2.1+"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/ruby-gnome2_app_driver"


### PR DESCRIPTION
- Drop support for Ruby 2.7
- Build with Rubies 3.0 through 3.3 in CI
