### PR TITLE
Replace soft-deprecated runtime dependency specification

### DIFF
--- a/gnome_app_driver.gemspec
+++ b/gnome_app_driver.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = ["README.md", "Changelog.md"]
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "gobject-introspection", ">= 3.2", "< 5.0"
+  spec.add_dependency "gobject-introspection", ">= 3.2", "< 5.0"
 
   spec.add_development_dependency "gtk3", ">= 3.2", "< 5.0"
   spec.add_development_dependency "minitest", "~> 5.12"


### PR DESCRIPTION
Using add_runtime_dependency is soft-deprecated and now flagged by RuboCop.
