### PR TITLE
Support Ruby 3.1 through 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/gnome_app_driver.gemspec
+++ b/gnome_app_driver.gemspec
@@ -13,8 +13,9 @@ Gem::Specification.new do |spec|
     Driver to test the UI of applications using Ruby-GNOME2 by interacting with them via Atspi.
   DESC
   spec.homepage = "http://www.github.com/mvz/ruby-gnome2_app_driver"
+
   spec.license = "LGPL-2.1+"
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/ruby-gnome2_app_driver"


### PR DESCRIPTION
This drops support for Ruby 3.0 which is EOL.
